### PR TITLE
Properly set text response from Mistral OCR

### DIFF
--- a/src/UI/Features/Ocr/OcrViewModel.cs
+++ b/src/UI/Features/Ocr/OcrViewModel.cs
@@ -2332,6 +2332,8 @@ public partial class OcrViewModel : ObservableObject
                 var text = await mistralOcr.Ocr(bitmap, SelectedOllamaLanguage ?? "English", _cancellationTokenSource.Token);
                 item.Text = text;
 
+                OcrFixLineAndSetText(i, item);
+
                 if (SelectedOcrSubtitleItem == item)
                 {
                     CurrentText = text;


### PR DESCRIPTION
Prior to this, the UI would only be partially updated after a response from Mistral OCR, and would be left in a broken state where the text for the line was uneditable. This fix ensures we properly update the state.

<img width="1621" height="616" alt="image" src="https://github.com/user-attachments/assets/793eb993-ff88-47e3-9a72-bec7f6a8b6f3" />
